### PR TITLE
Fix LsaAllocateLocallyUniqueId import location

### DIFF
--- a/FindGT/FindGT.cs
+++ b/FindGT/FindGT.cs
@@ -133,57 +133,135 @@ namespace FindGT
             else
                 Console.WriteLine(@"Error : {0}", err);
 
+            string domainDnsName = null;
+            string domainControllerName = null;
+            PrincipalContext principalContext = null;
+
+            try
+            {
+                Domain computerDomain = Domain.GetComputerDomain();
+                domainDnsName = computerDomain.Name;
+                DomainController domainController = computerDomain.FindDomainController();
+                domainControllerName = domainController.Name;
+                principalContext = new PrincipalContext(ContextType.Domain, domainDnsName);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"  [!] Unable to resolve domain controller information: {ex.Message}");
+            }
+
             foreach (var session in logonSessions.Where(s => s.Value.AuthPackage == "Kerberos").ToList())
             {
                 ulong luid = 0;
                 ulong.TryParse(session.Value.Luid, out luid);
                 LUID userLuid = new LUID(luid);
                 IntPtr hToken = Creds.NegotiateToken(userLuid, null, true);
-                Dictionary<string, string> groupMembership = new Dictionary<string, string>();
                 string sidString = session.Value.SID;
                 SecurityIdentifier sid = new SecurityIdentifier(sidString);
 
-                List<string> groupSids = Helpers.GetTokenGroups(hToken).Where(g => g.StartsWith("S-1-5-21-") && g != "S-1-5-21-0-0-0-497" && !g.StartsWith(MachineSIDString)).ToList();
+                List<string> groupSids = Helpers.GetTokenGroups(hToken)
+                    .Where(g => g.StartsWith("S-1-5-21-") && g != "S-1-5-21-0-0-0-497" && !g.StartsWith(MachineSIDString))
+                    .ToList();
 
-                PrincipalContext principalContext = new PrincipalContext(ContextType.Domain, Domain.GetComputerDomain().Name);
-                foreach (var group in groupSids)
+                if (principalContext != null)
                 {
-                    Principal foundPrincipal = Principal.FindByIdentity(principalContext, IdentityType.Sid, group);
+                    foreach (var group in groupSids)
+                    {
+                        try
+                        {
+                            Principal foundPrincipal = Principal.FindByIdentity(principalContext, IdentityType.Sid, group);
 
-                    if (foundPrincipal is GroupPrincipal)
-                    {
-                        //Console.WriteLine($"The object with SID {sidToCheck} is a Group.");
-                    }
-                    else if (foundPrincipal is UserPrincipal)
-                    {
-                        Console.WriteLine($"Token on User {sid} in Session {string.Format("0x{0:X}", luid)}\nContains object with SID {group} that is a User.");
-                    }
-                    else
-                    {
-                        Console.WriteLine($"Token on User {sid} in Session {string.Format("0x{0:X}", luid)}\nContains object with SID {group} of some type or does not exist.");
+                            if (foundPrincipal is UserPrincipal)
+                            {
+                                Console.WriteLine($"Token on User {sid} in Session {string.Format("0x{0:X}", luid)}\nContains object with SID {group} that is a User.");
+                            }
+                            else if (foundPrincipal == null)
+                            {
+                                Console.WriteLine($"Token on User {sid} in Session {string.Format("0x{0:X}", luid)}\nContains object with SID {group} that could not be resolved.");
+                            }
+                        }
+                        catch (Exception lookupEx)
+                        {
+                            Console.WriteLine($"  [!] Failed to resolve SID {group}: {lookupEx.Message}");
+                        }
                     }
                 }
 
+                HashSet<string> netlogonGroupSids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 try
                 {
-                    GetGroups(sid, groupMembership, Domain.GetComputerDomain().Name);
+                    string userDomainNetbios = null;
+                    string sessionUserName = session.Value.UserName ?? string.Empty;
+                    int separatorIndex = sessionUserName.IndexOf('\\');
+                    if (separatorIndex >= 0)
+                    {
+                        userDomainNetbios = sessionUserName.Substring(0, separatorIndex);
+                    }
+
+                    NetlogonValidationSamInfo validationInfo = NetlogonHelper.GetValidationSamInfo(
+                        sid,
+                        session.Value.UserName,
+                        userDomainNetbios,
+                        domainDnsName,
+                        domainControllerName);
+
+                    if (validationInfo != null)
+                    {
+                        if (validationInfo.LogonDomainId != null && validationInfo.GroupIds != null)
+                        {
+                            string domainSidValue = validationInfo.LogonDomainId.Value;
+                            foreach (var membership in validationInfo.GroupIds)
+                            {
+                                try
+                                {
+                                    SecurityIdentifier groupSid = new SecurityIdentifier(domainSidValue + "-" + membership.RelativeId);
+                                    netlogonGroupSids.Add(groupSid.Value);
+                                }
+                                catch (Exception buildEx)
+                                {
+                                    Console.WriteLine($"  [!] Failed to build SID for RID {membership.RelativeId}: {buildEx.Message}");
+                                }
+                            }
+                        }
+
+                        if (validationInfo.ExtraSids != null)
+                        {
+                            foreach (var extra in validationInfo.ExtraSids)
+                            {
+                                if (extra.Sid != null)
+                                {
+                                    netlogonGroupSids.Add(extra.Sid.Value);
+                                }
+                            }
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"An error occurred: {ex.Message}");
+                    Console.WriteLine($"  [!] Netlogon lookup failed for {session.Value.UserName}: {ex.Message}");
                 }
 
                 Console.WriteLine("Token on User {0} in Session {1} contains {2} groups", sid, string.Format("0x{0:X}", luid), groupSids.Count);
-                Console.WriteLine("IRL User {0} belongs to {2} groups", sid, string.Format("0x{0:X}", luid), groupMembership.Count);
+                Console.WriteLine("Netlogon reports {0} groups for {1}", netlogonGroupSids.Count, sid);
 
                 foreach (var group in groupSids)
-                    if (!groupMembership.ContainsKey(group))
-                        Console.WriteLine("Token on User {0} in Session {1} contains {2} but doesn't", sid, string.Format("0x{0:X}", luid), group);
+                {
+                    if (!netlogonGroupSids.Contains(group))
+                    {
+                        Console.WriteLine("Token on User {0} in Session {1} contains {2} but Netlogon membership does not", sid, string.Format("0x{0:X}", luid), group);
+                    }
+                }
 
-                foreach (var group in groupMembership)
-                    if (!groupSids.Contains(group.Key))
-                        Console.WriteLine("Token on User {0} in Session {1} doesn't contains {2} but should", sid, string.Format("0x{0:X}", luid), group.Key);
+                foreach (var groupSid in netlogonGroupSids)
+                {
+                    if (!groupSids.Contains(groupSid))
+                    {
+                        Console.WriteLine("Token on User {0} in Session {1} doesn't contain {2} but Netlogon membership includes it", sid, string.Format("0x{0:X}", luid), groupSid);
+                    }
+                }
             }
+
+            principalContext?.Dispose();
         }
     }
 }

--- a/FindGT/FindGT.csproj
+++ b/FindGT/FindGT.csproj
@@ -93,6 +93,8 @@
     <Compile Include="Helpers.cs" />
     <Compile Include="Interop.cs" />
     <Compile Include="LUID.cs" />
+    <Compile Include="NetlogonHelper.cs" />
+    <Compile Include="NetlogonValidationSamInfo.cs" />
     <Compile Include="FindGT.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SecBuffer.cs" />

--- a/FindGT/Helpers.cs
+++ b/FindGT/Helpers.cs
@@ -45,6 +45,76 @@ namespace FindGT
             return groupSids;
         }
 
+        public struct TokenGroup
+        {
+            public SecurityIdentifier Sid;
+            public uint Attributes;
+        }
+
+        public static List<TokenGroup> GetTokenGroupsWithAttributes(IntPtr token)
+        {
+            List<TokenGroup> groups = new List<TokenGroup>();
+            IntPtr pGroups = IntPtr.Zero;
+
+            try
+            {
+                pGroups = GetTokenInfo(token, Interop.TOKEN_INFORMATION_CLASS.TokenGroups);
+                Interop.TOKEN_GROUPS tokenGroups = (Interop.TOKEN_GROUPS)Marshal.PtrToStructure(pGroups, typeof(Interop.TOKEN_GROUPS));
+
+                int sidAndAttrSize = Marshal.SizeOf(typeof(Interop.SID_AND_ATTRIBUTES));
+                IntPtr groupsPtr = new IntPtr(pGroups.ToInt64() + Marshal.OffsetOf(typeof(Interop.TOKEN_GROUPS), "Groups").ToInt64());
+
+                for (int i = 0; i < tokenGroups.GroupCount; i++)
+                {
+                    IntPtr entryPtr = new IntPtr(groupsPtr.ToInt64() + sidAndAttrSize * i);
+                    Interop.SID_AND_ATTRIBUTES sidAndAttributes = (Interop.SID_AND_ATTRIBUTES)Marshal.PtrToStructure(entryPtr, typeof(Interop.SID_AND_ATTRIBUTES));
+
+                    if (sidAndAttributes.Sid != IntPtr.Zero)
+                    {
+                        groups.Add(new TokenGroup
+                        {
+                            Sid = new SecurityIdentifier(sidAndAttributes.Sid),
+                            Attributes = sidAndAttributes.Attributes
+                        });
+                    }
+                }
+            }
+            finally
+            {
+                if (pGroups != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(pGroups);
+                }
+            }
+
+            return groups;
+        }
+
+        public static SecurityIdentifier GetTokenPrimaryGroup(IntPtr token)
+        {
+            IntPtr pPrimaryGroup = IntPtr.Zero;
+
+            try
+            {
+                pPrimaryGroup = GetTokenInfo(token, Interop.TOKEN_INFORMATION_CLASS.TokenPrimaryGroup);
+                Interop.TOKEN_PRIMARY_GROUP primaryGroup = (Interop.TOKEN_PRIMARY_GROUP)Marshal.PtrToStructure(pPrimaryGroup, typeof(Interop.TOKEN_PRIMARY_GROUP));
+
+                if (primaryGroup.PrimaryGroup == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                return new SecurityIdentifier(primaryGroup.PrimaryGroup);
+            }
+            finally
+            {
+                if (pPrimaryGroup != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(pPrimaryGroup);
+                }
+            }
+        }
+
         public static IntPtr GetTokenInfo(IntPtr token, Interop.TOKEN_INFORMATION_CLASS informationClass)
         {
             // Wrapper that uses GetTokenInformation to retrieve the specified TOKEN_INFORMATION_CLASS

--- a/FindGT/Interop.cs
+++ b/FindGT/Interop.cs
@@ -41,6 +41,16 @@ namespace FindGT
             CachedUnlock            // attempt to unlock a workstation
         }
 
+        public enum MSV1_0_LOGON_SUBMIT_TYPE : uint
+        {
+            MsV1_0InteractiveLogon = 2,
+            MsV1_0Lm20Logon,
+            MsV1_0NetworkLogon,
+            MsV1_0SubAuthLogon,
+            MsV1_0WorkstationUnlockLogon = 7,
+            MsV1_0S4ULogon = 12
+        }
+
         public enum TOKEN_INFORMATION_CLASS
         {
             TokenUser = 1,
@@ -112,6 +122,12 @@ namespace FindGT
         }
 
         [StructLayout(LayoutKind.Sequential)]
+        public struct TOKEN_PRIMARY_GROUP
+        {
+            public IntPtr PrimaryGroup;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
         public struct LUID_AND_ATTRIBUTES
         {
             public LUID Luid;
@@ -125,6 +141,14 @@ namespace FindGT
 
         [StructLayout(LayoutKind.Sequential)]
         public struct LSA_STRING
+        {
+            public ushort Length;
+            public ushort MaximumLength;
+            public IntPtr Buffer;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct UNICODE_STRING
         {
             public ushort Length;
             public ushort MaximumLength;
@@ -189,6 +213,34 @@ namespace FindGT
                 }
             }
         };
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct TOKEN_SOURCE
+        {
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
+            public byte[] SourceName;
+            public LUID SourceIdentifier;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct QUOTA_LIMITS
+        {
+            public UIntPtr PagedPoolLimit;
+            public UIntPtr NonPagedPoolLimit;
+            public UIntPtr MinimumWorkingSetSize;
+            public UIntPtr MaximumWorkingSetSize;
+            public UIntPtr PagefileLimit;
+            public long TimeLimit;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MSV1_0_S4U_LOGON
+        {
+            public MSV1_0_LOGON_SUBMIT_TYPE MessageType;
+            public uint Flags;
+            public UNICODE_STRING UserPrincipalName;
+            public UNICODE_STRING DomainName;
+        }
 
         #endregion
 
@@ -326,6 +378,49 @@ namespace FindGT
             IntPtr luid,
             out IntPtr ppLogonSessionData
         );
+
+        [DllImport("Secur32.dll", SetLastError = false)]
+        public static extern uint LsaRegisterLogonProcess(
+            ref LSA_STRING LogonProcessName,
+            out IntPtr LsaHandle,
+            out ulong SecurityMode
+        );
+
+        [DllImport("Secur32.dll", SetLastError = false)]
+        public static extern uint LsaDeregisterLogonProcess(
+            IntPtr LsaHandle
+        );
+
+        [DllImport("Secur32.dll", SetLastError = false)]
+        public static extern uint LsaLookupAuthenticationPackage(
+            IntPtr LsaHandle,
+            ref LSA_STRING PackageName,
+            out uint AuthenticationPackage
+        );
+
+        [DllImport("Secur32.dll", SetLastError = false)]
+        public static extern uint LsaLogonUser(
+            IntPtr LsaHandle,
+            ref LSA_STRING OriginName,
+            SECURITY_LOGON_TYPE LogonType,
+            uint AuthenticationPackage,
+            IntPtr AuthenticationInformation,
+            uint AuthenticationInformationLength,
+            IntPtr LocalGroups,
+            ref TOKEN_SOURCE SourceContext,
+            out IntPtr ProfileBuffer,
+            out uint ProfileBufferLength,
+            out LUID LogonId,
+            out IntPtr Token,
+            out QUOTA_LIMITS Quotas,
+            out uint SubStatus
+        );
+
+        [DllImport("Secur32.dll", SetLastError = false)]
+        public static extern uint LsaNtStatusToWinError(uint Status);
+
+        [DllImport("advapi32.dll", SetLastError = false)]
+        public static extern uint LsaAllocateLocallyUniqueId(out LUID Luid);
 
         [DllImport("advapi32.dll", SetLastError = true)]
         public static extern bool GetTokenInformation(

--- a/FindGT/NetlogonHelper.cs
+++ b/FindGT/NetlogonHelper.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+using System.Text;
+
+namespace FindGT
+{
+    public static class NetlogonHelper
+    {
+        private const uint LOGON_EXTRA_SIDS = 0x20;
+        private const string LogonProcessName = "FindGT";
+        private const string AuthenticationPackage = "MICROSOFT_AUTHENTICATION_PACKAGE_V1_0";
+
+        public static NetlogonValidationSamInfo GetValidationSamInfo(
+            SecurityIdentifier userSid,
+            string userName,
+            string domainNetbios = null,
+            string dnsDomainName = null,
+            string domainController = null)
+        {
+            if (userSid == null)
+            {
+                throw new ArgumentNullException(nameof(userSid));
+            }
+
+            if (string.IsNullOrWhiteSpace(userName))
+            {
+                throw new ArgumentException("User name cannot be empty", nameof(userName));
+            }
+
+            string samAccountName = userName;
+            string explicitDomain = domainNetbios;
+
+            if (samAccountName.Contains("\\"))
+            {
+                string[] parts = samAccountName.Split(new[] { '\\' }, 2);
+                if (parts.Length == 2)
+                {
+                    if (string.IsNullOrEmpty(explicitDomain))
+                    {
+                        explicitDomain = parts[0];
+                    }
+                    samAccountName = parts[1];
+                }
+            }
+            else if (samAccountName.Contains("@"))
+            {
+                string[] parts = samAccountName.Split(new[] { '@' }, 2);
+                if (parts.Length == 2 && string.IsNullOrEmpty(dnsDomainName))
+                {
+                    dnsDomainName = parts[1];
+                }
+                if (parts.Length == 2)
+                {
+                    samAccountName = parts[0];
+                }
+            }
+
+            if (string.IsNullOrEmpty(explicitDomain))
+            {
+                try
+                {
+                    NTAccount account = (NTAccount)userSid.Translate(typeof(NTAccount));
+                    string[] nameParts = account.Value.Split('\\');
+                    if (nameParts.Length == 2)
+                    {
+                        explicitDomain = nameParts[0];
+                    }
+                }
+                catch
+                {
+                    // ignore translation errors
+                }
+            }
+
+            IntPtr logonProcessBuffer = IntPtr.Zero;
+            IntPtr originNameBuffer = IntPtr.Zero;
+            IntPtr packageNameBuffer = IntPtr.Zero;
+            IntPtr upnBuffer = IntPtr.Zero;
+            IntPtr domainBuffer = IntPtr.Zero;
+            IntPtr logonBuffer = IntPtr.Zero;
+            IntPtr profileBuffer = IntPtr.Zero;
+            IntPtr tokenHandle = IntPtr.Zero;
+            IntPtr lsaHandle = IntPtr.Zero;
+
+            try
+            {
+                Interop.LSA_STRING logonProcessName = CreateLsaString(LogonProcessName, out logonProcessBuffer);
+
+                ulong securityMode;
+                uint ntstatus = Interop.LsaRegisterLogonProcess(ref logonProcessName, out lsaHandle, out securityMode);
+                if (ntstatus != 0)
+                {
+                    throw new Win32Exception((int)Interop.LsaNtStatusToWinError(ntstatus));
+                }
+
+                Interop.LSA_STRING originName = CreateLsaString(LogonProcessName, out originNameBuffer);
+                Interop.LSA_STRING packageName = CreateLsaString(AuthenticationPackage, out packageNameBuffer);
+
+                uint authenticationPackage;
+                ntstatus = Interop.LsaLookupAuthenticationPackage(lsaHandle, ref packageName, out authenticationPackage);
+                if (ntstatus != 0)
+                {
+                    throw new Win32Exception((int)Interop.LsaNtStatusToWinError(ntstatus));
+                }
+
+                string upnValue = BuildUpn(samAccountName, dnsDomainName, userName);
+                Interop.UNICODE_STRING userPrincipalName = CreateUnicodeString(upnValue, out upnBuffer);
+                Interop.UNICODE_STRING domainName = CreateUnicodeString(explicitDomain, out domainBuffer);
+
+                Interop.MSV1_0_S4U_LOGON s4uLogon = new Interop.MSV1_0_S4U_LOGON
+                {
+                    MessageType = Interop.MSV1_0_LOGON_SUBMIT_TYPE.MsV1_0S4ULogon,
+                    Flags = 0,
+                    UserPrincipalName = userPrincipalName,
+                    DomainName = domainName
+                };
+
+                int logonSize = Marshal.SizeOf(typeof(Interop.MSV1_0_S4U_LOGON));
+                logonBuffer = Marshal.AllocHGlobal(logonSize);
+                Marshal.StructureToPtr(s4uLogon, logonBuffer, false);
+
+                Interop.TOKEN_SOURCE sourceContext = new Interop.TOKEN_SOURCE
+                {
+                    SourceName = new byte[8]
+                };
+                byte[] sourceNameBytes = Encoding.ASCII.GetBytes(LogonProcessName);
+                Array.Copy(sourceNameBytes, sourceContext.SourceName, Math.Min(sourceNameBytes.Length, sourceContext.SourceName.Length));
+
+                ntstatus = Interop.LsaAllocateLocallyUniqueId(out sourceContext.SourceIdentifier);
+                if (ntstatus != 0)
+                {
+                    throw new Win32Exception((int)Interop.LsaNtStatusToWinError(ntstatus));
+                }
+
+                LUID logonId;
+                Interop.QUOTA_LIMITS quotas;
+                uint profileLength;
+                uint subStatus;
+
+                ntstatus = Interop.LsaLogonUser(
+                    lsaHandle,
+                    ref originName,
+                    Interop.SECURITY_LOGON_TYPE.Network,
+                    authenticationPackage,
+                    logonBuffer,
+                    (uint)logonSize,
+                    IntPtr.Zero,
+                    ref sourceContext,
+                    out profileBuffer,
+                    out profileLength,
+                    out logonId,
+                    out tokenHandle,
+                    out quotas,
+                    out subStatus);
+
+                if (ntstatus != 0)
+                {
+                    throw new Win32Exception((int)Interop.LsaNtStatusToWinError(ntstatus));
+                }
+
+                NetlogonValidationSamInfo info = BuildValidationInfo(userSid, samAccountName, explicitDomain, dnsDomainName, domainController, tokenHandle);
+                return info;
+            }
+            finally
+            {
+                if (tokenHandle != IntPtr.Zero)
+                {
+                    Interop.CloseHandle(tokenHandle);
+                }
+
+                if (profileBuffer != IntPtr.Zero)
+                {
+                    Interop.LsaFreeReturnBuffer(profileBuffer);
+                }
+
+                if (logonBuffer != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(logonBuffer);
+                }
+
+                if (upnBuffer != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(upnBuffer);
+                }
+
+                if (domainBuffer != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(domainBuffer);
+                }
+
+                if (packageNameBuffer != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(packageNameBuffer);
+                }
+
+                if (originNameBuffer != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(originNameBuffer);
+                }
+
+                if (logonProcessBuffer != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(logonProcessBuffer);
+                }
+
+                if (lsaHandle != IntPtr.Zero)
+                {
+                    Interop.LsaDeregisterLogonProcess(lsaHandle);
+                }
+            }
+        }
+
+        private static NetlogonValidationSamInfo BuildValidationInfo(
+            SecurityIdentifier userSid,
+            string samAccountName,
+            string domainNetbios,
+            string dnsDomainName,
+            string domainController,
+            IntPtr tokenHandle)
+        {
+            SecurityIdentifier domainSid = userSid.AccountDomainSid ?? userSid;
+            SecurityIdentifier primaryGroup = Helpers.GetTokenPrimaryGroup(tokenHandle);
+            List<Helpers.TokenGroup> tokenGroups = Helpers.GetTokenGroupsWithAttributes(tokenHandle);
+
+            NetlogonValidationSamInfo info = new NetlogonValidationSamInfo
+            {
+                EffectiveName = samAccountName,
+                LogonDomainName = domainNetbios ?? string.Empty,
+                LogonDomainId = domainSid,
+                LogonServer = string.IsNullOrEmpty(domainController) ? Environment.MachineName : domainController,
+                LogonTime = DateTime.UtcNow,
+                DnsLogonDomainName = !string.IsNullOrEmpty(dnsDomainName) ? dnsDomainName : domainNetbios,
+                Upn = BuildUpn(samAccountName, dnsDomainName, null),
+                UserId = GetRid(userSid),
+                PrimaryGroupId = GetRid(primaryGroup)
+            };
+
+            if (tokenGroups != null)
+            {
+                foreach (Helpers.TokenGroup group in tokenGroups)
+                {
+                    SecurityIdentifier groupDomainSid = group.Sid.AccountDomainSid;
+                    if (domainSid != null && groupDomainSid != null && groupDomainSid.Equals(domainSid))
+                    {
+                        info.GroupIds.Add(new GroupMembership
+                        {
+                            RelativeId = GetRid(group.Sid),
+                            Attributes = group.Attributes
+                        });
+                    }
+                    else
+                    {
+                        info.ExtraSids.Add(new NetlogonSidAndAttributes
+                        {
+                            Sid = group.Sid,
+                            Attributes = group.Attributes
+                        });
+                    }
+                }
+            }
+
+            info.SidCount = (uint)info.ExtraSids.Count;
+            if (info.ExtraSids.Count > 0)
+            {
+                info.UserFlags |= LOGON_EXTRA_SIDS;
+            }
+
+            return info;
+        }
+
+        private static Interop.LSA_STRING CreateLsaString(string value, out IntPtr buffer)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                buffer = IntPtr.Zero;
+                return new Interop.LSA_STRING
+                {
+                    Length = 0,
+                    MaximumLength = 0,
+                    Buffer = IntPtr.Zero
+                };
+            }
+
+            buffer = Marshal.StringToHGlobalAnsi(value);
+            return new Interop.LSA_STRING
+            {
+                Length = (ushort)value.Length,
+                MaximumLength = (ushort)(value.Length + 1),
+                Buffer = buffer
+            };
+        }
+
+        private static Interop.UNICODE_STRING CreateUnicodeString(string value, out IntPtr buffer)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                buffer = IntPtr.Zero;
+                return new Interop.UNICODE_STRING
+                {
+                    Length = 0,
+                    MaximumLength = 0,
+                    Buffer = IntPtr.Zero
+                };
+            }
+
+            buffer = Marshal.StringToHGlobalUni(value);
+            return new Interop.UNICODE_STRING
+            {
+                Length = (ushort)(value.Length * 2),
+                MaximumLength = (ushort)((value.Length + 1) * 2),
+                Buffer = buffer
+            };
+        }
+
+        private static uint GetRid(SecurityIdentifier sid)
+        {
+            if (sid == null)
+            {
+                return 0;
+            }
+
+            string[] parts = sid.Value.Split('-');
+            if (parts.Length == 0)
+            {
+                return 0;
+            }
+
+            string last = parts[parts.Length - 1];
+            if (uint.TryParse(last, out uint rid))
+            {
+                return rid;
+            }
+
+            return 0;
+        }
+
+        private static string BuildUpn(string samAccountName, string dnsDomainName, string originalUserName)
+        {
+            if (!string.IsNullOrEmpty(originalUserName) && originalUserName.Contains("@"))
+            {
+                return originalUserName;
+            }
+
+            if (!string.IsNullOrEmpty(samAccountName) && !string.IsNullOrEmpty(dnsDomainName))
+            {
+                return string.Format("{0}@{1}", samAccountName, dnsDomainName);
+            }
+
+            return samAccountName;
+        }
+    }
+}

--- a/FindGT/NetlogonValidationSamInfo.cs
+++ b/FindGT/NetlogonValidationSamInfo.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Principal;
+
+namespace FindGT
+{
+    public class NetlogonValidationSamInfo
+    {
+        public DateTime? LogonTime { get; set; }
+        public DateTime? LogoffTime { get; set; }
+        public DateTime? KickOffTime { get; set; }
+        public DateTime? PasswordLastSet { get; set; }
+        public DateTime? PasswordCanChange { get; set; }
+        public DateTime? PasswordMustChange { get; set; }
+        public string EffectiveName { get; set; }
+        public string FullName { get; set; }
+        public string LogonScript { get; set; }
+        public string ProfilePath { get; set; }
+        public string HomeDirectory { get; set; }
+        public string HomeDirectoryDrive { get; set; }
+        public ushort LogonCount { get; set; }
+        public ushort BadPasswordCount { get; set; }
+        public uint UserId { get; set; }
+        public uint PrimaryGroupId { get; set; }
+        public List<GroupMembership> GroupIds { get; set; } = new List<GroupMembership>();
+        public uint UserFlags { get; set; }
+        public byte[] UserSessionKey { get; set; } = new byte[16];
+        public string LogonServer { get; set; }
+        public string LogonDomainName { get; set; }
+        public SecurityIdentifier LogonDomainId { get; set; }
+        public List<int> ExpansionRoom { get; set; } = new List<int>(new int[10]);
+        public uint SidCount { get; set; }
+        public List<NetlogonSidAndAttributes> ExtraSids { get; set; } = new List<NetlogonSidAndAttributes>();
+        public byte[] LmKey { get; set; } = new byte[8];
+        public uint UserAccountControl { get; set; }
+        public uint SubAuthStatus { get; set; }
+        public DateTime? LastSuccessfulLogon { get; set; }
+        public DateTime? LastFailedLogon { get; set; }
+        public uint FailedILogonCount { get; set; }
+        public uint Reserved4 { get; set; }
+        public string DnsLogonDomainName { get; set; }
+        public string Upn { get; set; }
+        public List<string> ExpansionStrings { get; set; } = new List<string>(new string[10]);
+    }
+
+    public struct GroupMembership
+    {
+        public uint RelativeId { get; set; }
+        public uint Attributes { get; set; }
+    }
+
+    public struct NetlogonSidAndAttributes
+    {
+        public SecurityIdentifier Sid { get; set; }
+        public uint Attributes { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- correct the LsaAllocateLocallyUniqueId P/Invoke to resolve the entry point from advapi32.dll instead of secur32.dll

## Testing
- dotnet build FindGT.sln *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c92c4b4d18832ab6ff9bc6c427f97c